### PR TITLE
ports: add man-db(ft: libpipeline, groff and texinfo)

### DIFF
--- a/ports/groff/pkgfile
+++ b/ports/groff/pkgfile
@@ -1,0 +1,4 @@
+info='GNU troff text-formatting system'
+version=1.22.4
+source=http://ftp.gnu.org/gnu/$name/$name-$version.tar.gz
+deps='zlib texinfo'

--- a/ports/libpipeline/pkgfile
+++ b/ports/libpipeline/pkgfile
@@ -1,0 +1,4 @@
+info='a C library for manipulating pipelines of subprocesses in a flexible and convenient way'
+version=1.5.1
+source=http://download.savannah.nongnu.org/releases/$name/$name-$version.tar.gz
+deps='pkgconf'

--- a/ports/man-db/pkgfile
+++ b/ports/man-db/pkgfile
@@ -1,0 +1,4 @@
+info='implementation of the standard Unix documentation system accessed using the man command'
+version=2.8.5
+source=http://download.savannah.nongnu.org/releases/$name/$name-$version.tar.xz
+deps='libpipeline gdbm groff zlib'

--- a/ports/texinfo/pkgfile
+++ b/ports/texinfo/pkgfile
@@ -1,0 +1,3 @@
+info='the official documentation format of the GNU project'
+version=6.6
+source=http://ftp.gnu.org/gnu/$name/$name-$version.tar.gz


### PR DESCRIPTION
The build of `man-db` is currently not working because of an error I can't really understand, tough it produces the binaries in `/src/pkgs/man-db/bin`.

Can move in `ports-staging` if you wanna merge right away or we can debug it and merge afterward.