### PR TITLE
[WIP] ports: add symlinks to manpages

### DIFF
--- a/ports/groff/pkgfile
+++ b/ports/groff/pkgfile
@@ -10,6 +10,9 @@ build() {
 }
 postbuild() {
     ln -sf eqn "$pkg"/bin/geqn
+    ln -sf eqn.1 "$pkg"/share/man/man1/geqn.1
     ln -sf tbl "$pkg"/bin/gtbl
+    ln -sf tbl.1 "$pkg"/share/man/man1/gtbl.1
     ln -sf soelim "$pkg"/bin/zsoelim
+    ln -sf soelim.1 "$pkg"/share/man/man1/zsoelim.1
 }

--- a/ports/pemacs/pkgfile
+++ b/ports/pemacs/pkgfile
@@ -11,4 +11,5 @@ build() {
 }
 postbuild() {
     ln -sf pe "$pkg"/bin/pemacs
+    ln -sf pe.1 "$pkg"/share/man/man1/pemacs.1
 }


### PR DESCRIPTION
Currently, `pemacs` is symlinked to `pe`. But the man page was not. So `man pe` worked, but `man pemacs` did not.

Edit: this is a problem with more packages, I will add them occasionally. Leave this open until then.

TODO:
- [x] pemacs
- [ ] samurai? - ninja?
- [ ] dropbear? - ssh? sshd?
- [ ] sinit? - init
- [ ] gcc-bin? - cc
- [ ] pkgconf? - pkg-config?
- [x] groff - geqn, gtbl, zsoelim